### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -8,27 +8,27 @@
 #######################################
 
 Pin	 KEYWORD1
-AnalogInputPin	 KEYWORD1
-DigitalInputPin	 KEYWORD1
-DigitalOutputPin	 KEYWORD1
-ActuatorBase	 KEYWORD1
-SwitchedInput	 KEYWORD1
-LowOnSwitchedInput	 KEYWORD1
-HighOnSwitchedInput	 KEYWORD1
-DigitalActuator	 KEYWORD1
-LowOnActuator	 KEYWORD1
-HighOnActuator	 KEYWORD1
+AnalogInputPin	KEYWORD1
+DigitalInputPin	KEYWORD1
+DigitalOutputPin	KEYWORD1
+ActuatorBase	KEYWORD1
+SwitchedInput	KEYWORD1
+LowOnSwitchedInput	KEYWORD1
+HighOnSwitchedInput	KEYWORD1
+DigitalActuator	KEYWORD1
+LowOnActuator	KEYWORD1
+HighOnActuator	KEYWORD1
 
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-readAnalog	 KEYWORD2
-writeDigital	 KEYWORD2
-writePWM	 KEYWORD2
-isOn	 KEYWORD2
-isOff	 KEYWORD2
+readAnalog	KEYWORD2
+writeDigital	KEYWORD2
+writePWM	KEYWORD2
+isOn	KEYWORD2
+isOff	KEYWORD2
 high	KEYWORD2
 low	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords